### PR TITLE
Autodemo

### DIFF
--- a/racesow/progs/gametypes/racesow/gametypes/race.as
+++ b/racesow/progs/gametypes/racesow/gametypes/race.as
@@ -169,11 +169,6 @@ class Racesow_Gametype_Race : Racesow_Gametype
     void scoreEvent( cClient @client, String &score_event, String &args )
     {
         Racesow_Player @player = Racesow_GetPlayerByClient( client );
-        if ( @player != null )
-        {
-            if ( score_event == "enterGame" && !player.isJoinlocked && !client.tv )
-                player.restartRace();
-        }
     }
     
     String @ScoreboardMessage( uint maxlen )

--- a/source/cgame/cg_cmds.c
+++ b/source/cgame/cg_cmds.c
@@ -396,8 +396,22 @@ static const char *CG_SC_RaceDemoName( unsigned int raceTime )
 {
 	unsigned int hour, min, sec, milli;
 
+	const char *cleanplayername, *cleanplayername2;
 	static char name[MAX_STRING_CHARS];
 	char mapname[MAX_CONFIGSTRING_CHARS];
+
+	if( cg.view.POVent <= 0 )
+	{
+		cleanplayername2 = "";
+	}
+	else
+	{
+		// remove color tokens from player names (doh)
+		cleanplayername = COM_RemoveColorTokens( cgs.clientInfo[cg.view.POVent-1].name );
+
+		// remove junk chars from player names for files
+		cleanplayername2 = COM_RemoveJunkChars( cleanplayername );
+	}
 
 	milli = raceTime;
 
@@ -413,10 +427,9 @@ static const char *CG_SC_RaceDemoName( unsigned int raceTime )
 	Q_strlwr( mapname );
 
 	// make file path
-	// "gametype/map/map_time_random"
-	Q_snprintfz( name, sizeof( name ), "%s/%s/%s_%02u-%02u-%02u-%003u_%04i",
+	Q_snprintfz( name, sizeof( name ), rs_autoDemoName->string,
+		cleanplayername2,
 		gs.gametypeName,
-		mapname,
 		mapname, hour, min, sec, milli,	(int)brandom( 0, 9999 )
 		);
 

--- a/source/cgame/cg_cmds.c
+++ b/source/cgame/cg_cmds.c
@@ -367,7 +367,15 @@ static const char *CG_SC_AutoRecordName( void )
 static qboolean CG_SC_RaceDemoRename( const char *src, const char *dst )
 {
 	char *baseDirectory = "demos"; //hardcoded string
-	int file;
+	int file, size;
+
+	// Check if src exists first
+	size = trap_FS_FOpenFile( va( "%s/%s", baseDirectory, src ), &file, FS_READ );
+	trap_FS_FCloseFile( file );
+	if ( size == -1 )
+	{
+		return qfalse;
+	}
 
 	if ( !trap_FS_MoveFile( va( "%s/%s", baseDirectory, src ), va( "%s/%s%s", baseDirectory, dst, APP_DEMO_EXTENSION_STR ) ) )
 	{

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -1003,6 +1003,7 @@ extern cvar_t *rc_playerTrailsColor;
 extern cvar_t *rc_playerTrailsAlpha;
 extern cvar_t *rc_playerTrailsSize;
 extern cvar_t *rs_autoRaceDemo;
+extern cvar_t *rs_autoDemoName;
 extern cvar_t *rs_autoRaceScreenshot;
 extern cvar_t *rs_ignoreTeleEffect;
 void RC_AddLinearTrail( centity_t *cent, float lifetime );

--- a/source/cgame/cg_main.c
+++ b/source/cgame/cg_main.c
@@ -60,6 +60,7 @@ cvar_t *rc_playerTrailsColor;
 cvar_t *rc_playerTrailsAlpha;
 cvar_t *rc_playerTrailsSize;
 cvar_t *rs_autoRaceDemo;
+cvar_t *rs_autoDemoName;
 cvar_t *rs_autoRaceScreenshot;
 cvar_t *rs_ignoreTeleEffect;
 //!racesow
@@ -540,6 +541,7 @@ static void CG_RegisterVariables( void )
 	rc_playerTrailsAlpha = trap_Cvar_Get( "rc_playerTrailsAlpha", "1.0", CVAR_ARCHIVE );
 	rc_playerTrailsSize = trap_Cvar_Get( "rc_playerTrailsSize", "1.5", CVAR_ARCHIVE );
 	rs_autoRaceDemo = trap_Cvar_Get( "rs_autoRaceDemo", "0", CVAR_ARCHIVE );
+	rs_autoDemoName = trap_Cvar_Get( "rs_autoDemoName", "%s/%s/%s_%02u-%02u-%02u-%003u_%04i", CVAR_USERINFO | CVAR_ARCHIVE );
 	rs_autoRaceScreenshot = trap_Cvar_Get( "rs_autoRaceScreenshot", "0", CVAR_ARCHIVE );
 	rs_ignoreTeleEffect = trap_Cvar_Get( "rs_ignoreTeleEffect", "0", CVAR_ARCHIVE );
 //!racesow


### PR DESCRIPTION
Working on #23

First this fixes the 0kb demo issue by checking if a file exists before renaming. This issue happens when `dstart` is called but `record` fails. The next `dstop` renames nothing to a demo.

Second, I introduce `rs_autoDemoName`, I haven't fixed the default name because we should discuss that first. Available tokens are playername, mapname, hour, min, sec, milli, random

This does not fix the issue with recording the very first run. When you join a server, `dstart` is called before you are actually ingame and `record` fails. Hardly a big issue since noone (except weqo?) ever recs their first attempt. We could look at delaying the first dstart call or putting players in spec when they join.
