### PR TITLE
Feature: Timer in practicemode

### DIFF
--- a/racesow/progs/gametypes/racesow/commands.as
+++ b/racesow/progs/gametypes/racesow/commands.as
@@ -885,7 +885,7 @@ class Command_Practicemode : Racesow_Command
                     leave = true;
                 else
                     leave = false;
-                if ( leave ^^ player.practicing )
+                if ( leave && player.practicing )
                     return true;
             }
 

--- a/racesow/progs/gametypes/racesow/commands.as
+++ b/racesow/progs/gametypes/racesow/commands.as
@@ -897,6 +897,7 @@ class Command_Practicemode : Racesow_Command
 			}
             else
             {
+                player.chronoStartTime = levelTime;
 				player.practicing = true;
                 player.inNoclip = false;
 				player.sendAward( S_COLOR_GREEN + "You have entered practice mode" );

--- a/racesow/progs/gametypes/racesow/main.as
+++ b/racesow/progs/gametypes/racesow/main.as
@@ -640,8 +640,8 @@ void GT_ThinkRules()
         client.setHUDStat( STAT_MESSAGE_ALPHA, 0 );
         client.setHUDStat( STAT_MESSAGE_BETA, 0 );
 
-    	if( player.isUsingChrono )
-    		client.setHUDStat( STAT_TIME_ALPHA, (levelTime - player.chronoTime()) / 100 );
+    	if( player.isUsingChrono || player.practicing )
+    		client.setHUDStat( STAT_TIME_SELF, (levelTime - player.chronoTime()) / 100 );
     }
 
     racesowGametype.ThinkRules();

--- a/racesow/progs/gametypes/racesow/player.as
+++ b/racesow/progs/gametypes/racesow/player.as
@@ -826,6 +826,9 @@ class Racesow_Player
         if( this.client.getEnt().team == TEAM_SPECTATOR )
             this.inNoclip = false;
 
+        if ( this.practicing )
+            this.chronoStartTime = levelTime;
+
   		if ( this.practicing && this.positionSaved )
   		{
   			this.teleport( this.positionOrigin, this.positionAngles, false, false, false );


### PR DESCRIPTION
Timer restarts when you spawn / enter practicemode, could be useful for comparing routes on sections of a map.

I think to make it more useful, there could be a way to report the time. Maybe report on /kill, checkpoint or custom command?
