### PR TITLE
Fix compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,13 @@ GAMETYPE_DIRECTORY = $(RACESOW_DIRECTORY)/progs/gametypes/racesow
 SOURCE_DIRECTORY = source
 RELEASE_DIRECTORY = $(SOURCE_DIRECTORY)/release/racesow
 
-.PHONY: doc
+.PHONY: all doc version gametype data source_i386 source_x64 source_x86 source_x86_64 modules modules_i386 modules_x64 modules_x86 modules_x86_64 install clean
 
-doc: 
+all: modules_x86_64 install
+
+doc:
 	cd doc; doxygen $(DOXYGEN_FILE)
-	
+
 version:
 	find $(GAMETYPE_DIRECTORY) -name "*.as" \
 	-exec sed -i -e 's/@version.*/@version $(PROJECT_VERSION_NUMBER)/' {} \;
@@ -25,7 +27,7 @@ version:
 	$(GAMETYPE_DIRECTORY)/main.as
 	sed -i -e 's/\(PROJECT_NUMBER *=\).*/\1 $(PROJECT_VERSION_NUMBER)/' \
 	$(DOC_DIRECTORY)/$(DOXYGEN_FILE)
-	
+
 gametype:
 	cd $(RACESOW_DIRECTORY); zip -r rs_gametype$(SIMPLE_VERSION_NUMBER)pure progs configs
 	mv $(RACESOW_DIRECTORY)/rs_gametype$(SIMPLE_VERSION_NUMBER)pure.zip rs_gametype$(SIMPLE_VERSION_NUMBER)pure.pk3
@@ -34,13 +36,31 @@ data:
 	cd $(RACESOW_DIRECTORY); zip -r rs_data$(SIMPLE_VERSION_NUMBER)pure gfx huds
 	mv $(RACESOW_DIRECTORY)/rs_data$(SIMPLE_VERSION_NUMBER)pure.zip rs_data$(SIMPLE_VERSION_NUMBER)pure.pk3
 
+source_i386:
+	cd $(SOURCE_DIRECTORY); make -f Makefile.i386 cgame game ui
+
+source_x64:
+	cd $(SOURCE_DIRECTORY); make -f Makefile.x64 cgame game ui
+
+source_x86:
+	cd $(SOURCE_DIRECTORY); make -f Makefile.x86 cgame game ui
+
+source_x86_64:
+	cd $(SOURCE_DIRECTORY); make -f Makefile.x86_64 cgame game ui
+
 modules:
-	cd $(SOURCE_DIRECTORY); make -f Makefile.i386 cgame game ui; make -f Makefile.x86 cgame game ui; make -f Makefile.x64 cgame game ui; \
-	make -f Makefile.x86_64 cgame game ui
 	printf "/*\n* Racesow manifest\n*/\n{\n\"Version\" \"$(PROJECT_VERSION_NUMBER)\"\n\"Author\" \"Racesow Dev Team\"\n}" > $(RELEASE_DIRECTORY)/manifest.txt
 	cd $(RELEASE_DIRECTORY); zip modules_rs_$(SIMPLE_VERSION_NUMBER) manifest.txt *.so *.dll *.dylib
 	mv $(RELEASE_DIRECTORY)/modules_rs_$(SIMPLE_VERSION_NUMBER).zip $(RELEASE_DIRECTORY)/modules_rs_$(SIMPLE_VERSION_NUMBER).pk3
 	rm $(RELEASE_DIRECTORY)/manifest.txt
+
+modules_i386: source_i386 modules
+
+modules_x64: source_x64 modules
+
+modules_x86: source_x86 modules
+
+modules_x86_64: source_x86_64 modules
 
 install: gametype data
 	mv  rs_data$(SIMPLE_VERSION_NUMBER)pure.pk3 rs_gametype$(SIMPLE_VERSION_NUMBER)pure.pk3 $(RELEASE_DIRECTORY)

--- a/libsrcs/libRocket/libRocket/Source/Core/FontDatabase.cpp
+++ b/libsrcs/libRocket/libRocket/Source/Core/FontDatabase.cpp
@@ -254,7 +254,7 @@ void* FontDatabase::LoadFace(const String& file_name)
 
 	if (!handle)
 	{
-		return false;
+		return NULL;
 	}
 
 	size_t length = file_interface->Length(handle);


### PR DESCRIPTION
Fixes a compile-time type error deep in libRocket. Also separates each compilation target in the Makefile so one platform can be built at a time.